### PR TITLE
feat: Implementing security features

### DIFF
--- a/applications/app-demo/build.gradle
+++ b/applications/app-demo/build.gradle
@@ -5,6 +5,9 @@ plugins {
 dependencies {
     implementation project(':components:module-demo')
     implementation project(':components:module-oauth')
+    implementation project(':components:module-security')
+    implementation project(':components:support-jwt')
+
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 

--- a/applications/app-demo/src/docs/asciidoc/index.adoc
+++ b/applications/app-demo/src/docs/asciidoc/index.adoc
@@ -19,3 +19,21 @@ endif::[]
 
 include::{snippets}/login-api-integration-test/login/http-request.adoc[]
 include::{snippets}/login-api-integration-test/login/http-response.adoc[]
+
+[[Security_API]]
+== Security API
+
+[[refresh_성공]]
+=== refresh_성공
+
+include::{snippets}/token-refresh-controller-test/refresh_성공/http-request.adoc[]
+include::{snippets}/token-refresh-controller-test/refresh_성공/http-response.adoc[]
+include::{snippets}/token-refresh-controller-test/refresh_성공/response-fields.adoc[]
+
+[[refresh_실패]]
+=== refresh_실패
+
+include::{snippets}/token-refresh-controller-test/refresh_실패/http-request.adoc[]
+include::{snippets}/token-refresh-controller-test/refresh_실패/http-response.adoc[]
+include::{snippets}/token-refresh-controller-test/refresh_실패/response-fields.adoc[]
+

--- a/applications/app-demo/src/test/java/depromeet/ohgzoo/iam/sucurity/RestDocsConfig.java
+++ b/applications/app-demo/src/test/java/depromeet/ohgzoo/iam/sucurity/RestDocsConfig.java
@@ -1,0 +1,20 @@
+package depromeet.ohgzoo.iam.sucurity;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+    @Bean
+    public RestDocumentationResultHandler write() {
+        return MockMvcRestDocumentation.document(
+                "{class-name}/{method-name}",
+                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+        );
+    }
+}

--- a/applications/app-demo/src/test/java/depromeet/ohgzoo/iam/sucurity/TokenRefreshControllerTest.java
+++ b/applications/app-demo/src/test/java/depromeet/ohgzoo/iam/sucurity/TokenRefreshControllerTest.java
@@ -1,0 +1,99 @@
+package depromeet.ohgzoo.iam.sucurity;
+
+import depromeet.ohgzoo.iam.jwt.JwtService;
+import depromeet.ohgzoo.iam.security.controller.TokenRefreshController;
+import depromeet.ohgzoo.iam.security.dto.AuthToken;
+import depromeet.ohgzoo.iam.security.exception.UnAuthenticationException;
+import depromeet.ohgzoo.iam.security.service.TokenRefreshService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TokenRefreshController.class)
+@ExtendWith(RestDocumentationExtension.class)
+@Import(RestDocsConfig.class)
+public class TokenRefreshControllerTest {
+
+    @MockBean
+    TokenRefreshService tokenRefreshService;
+
+    @MockBean
+    JwtService jwtService;
+
+    MockMvc mockMvc;
+
+    @Autowired
+    RestDocumentationResultHandler restDocs;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+                .alwaysDo(MockMvcResultHandlers.print())
+                .alwaysDo(restDocs)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+    @Test
+    @DisplayName("refresh_성공")
+    public void refresh_성공() throws Exception {
+        AuthToken authToken = new AuthToken("authToken", "refreshToken");
+        when(tokenRefreshService.createNewAuthToken(any())).thenReturn(authToken);
+
+        mockMvc.perform(get("/refresh"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.auth").value("authToken"))
+                .andExpect(jsonPath("$.refresh").value("refreshToken"))
+                .andDo(
+                        restDocs.document(
+                                responseFields(
+                                        fieldWithPath("auth").description("authToken"),
+                                        fieldWithPath("refresh").description("refreshToken")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    @DisplayName("refresh_실패")
+    public void refresh_실패() throws Exception {
+        UnAuthenticationException unAuthenticationException = new UnAuthenticationException("토큰이 만료되었습니다.");
+        when(tokenRefreshService.createNewAuthToken(any())).thenThrow(unAuthenticationException);
+
+        mockMvc.perform(get("/refresh"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.msg").value("토큰이 만료되었습니다."))
+                .andExpect(jsonPath("$.code").value("401"))
+                .andDo(
+                        restDocs.document(
+                                responseFields(
+                                        fieldWithPath("msg").description("토큰이 만료되었습니다."),
+                                        fieldWithPath("code").description("401")
+                                )
+                        )
+                );
+    }
+}

--- a/components/module-security/build.gradle
+++ b/components/module-security/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(':components:support-jwt')
+}

--- a/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/config/WebConfig.java
+++ b/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/config/WebConfig.java
@@ -1,0 +1,29 @@
+package depromeet.ohgzoo.iam.security.config;
+
+import depromeet.ohgzoo.iam.jwt.JwtService;
+import depromeet.ohgzoo.iam.security.interceptor.SecurityInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtService jwtService;
+    private List<String> whiteList = new ArrayList<>();
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        whiteList.addAll(List.of("/css/**", "/*.ico", "/error", "/refresh", "/docs/**", "/oauth2/**", "/login/**"));
+
+        registry.addInterceptor(new SecurityInterceptor(jwtService))
+                .order(1)
+                .addPathPatterns("/**")
+                .excludePathPatterns(whiteList);
+    }
+}

--- a/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/controller/ControllerAdvice.java
+++ b/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/controller/ControllerAdvice.java
@@ -1,0 +1,18 @@
+package depromeet.ohgzoo.iam.security.controller;
+
+import depromeet.ohgzoo.iam.security.dto.CommonResult;
+import depromeet.ohgzoo.iam.security.exception.UnAuthenticationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public CommonResult authenticationExHandle(UnAuthenticationException ex) {
+        return new CommonResult(ex.getMessage(), "401");
+    }
+}

--- a/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/controller/TokenRefreshController.java
+++ b/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/controller/TokenRefreshController.java
@@ -1,0 +1,38 @@
+package depromeet.ohgzoo.iam.security.controller;
+
+import depromeet.ohgzoo.iam.security.dto.AuthToken;
+import depromeet.ohgzoo.iam.security.exception.UnAuthenticationException;
+import depromeet.ohgzoo.iam.security.service.TokenRefreshService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenRefreshController {
+
+    private final TokenRefreshService tokenRefreshService;
+
+    @GetMapping("/refresh")
+    public AuthToken refreshToken(HttpServletRequest request) throws UnAuthenticationException {
+        return tokenRefreshService.createNewAuthToken(request);
+    }
+
+    @GetMapping("/pathexcludetest1")
+    public String pathExcludeTest1() {
+        return "ok1";
+    }
+
+    @GetMapping("/pathexcludetest2")
+    public String pathExcludeTest2() {
+        return "ok2";
+    }
+
+    @GetMapping("/validtoken")
+    public String validToken() {
+        return "valid token";
+    }
+
+}

--- a/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/dto/AuthToken.java
+++ b/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/dto/AuthToken.java
@@ -1,0 +1,14 @@
+package depromeet.ohgzoo.iam.security.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AuthToken {
+    private final String auth;
+    private final String refresh;
+
+    public AuthToken(String auth, String refresh) {
+        this.auth = auth;
+        this.refresh = refresh;
+    }
+}

--- a/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/dto/CommonResult.java
+++ b/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/dto/CommonResult.java
@@ -1,0 +1,11 @@
+package depromeet.ohgzoo.iam.security.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CommonResult {
+    private String msg;
+    private String code;
+}

--- a/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/exception/UnAuthenticationException.java
+++ b/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/exception/UnAuthenticationException.java
@@ -1,0 +1,7 @@
+package depromeet.ohgzoo.iam.security.exception;
+
+public class UnAuthenticationException extends RuntimeException {
+    public UnAuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/interceptor/SecurityInterceptor.java
+++ b/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/interceptor/SecurityInterceptor.java
@@ -1,0 +1,30 @@
+package depromeet.ohgzoo.iam.security.interceptor;
+
+import depromeet.ohgzoo.iam.jwt.JwtService;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class SecurityInterceptor implements HandlerInterceptor {
+
+    private static final String AUTH_TOKEN = "AUTH_TOKEN";
+    private final JwtService jwtService;
+
+    public SecurityInterceptor(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String token = request.getHeader(AUTH_TOKEN);
+
+        if (StringUtils.hasText(token) && jwtService.verifyToken(token)) {
+            return true;
+        } else {
+            response.sendRedirect("/refresh?redirectURL=" + request.getRequestURI());
+            return false;
+        }
+    }
+}

--- a/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/service/TokenRefreshService.java
+++ b/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/service/TokenRefreshService.java
@@ -1,0 +1,10 @@
+package depromeet.ohgzoo.iam.security.service;
+
+import depromeet.ohgzoo.iam.security.dto.AuthToken;
+import depromeet.ohgzoo.iam.security.exception.UnAuthenticationException;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface TokenRefreshService {
+    AuthToken createNewAuthToken(HttpServletRequest request) throws UnAuthenticationException;
+}

--- a/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/service/TokenRefreshServiceImpl.java
+++ b/components/module-security/src/main/java/depromeet/ohgzoo/iam/security/service/TokenRefreshServiceImpl.java
@@ -1,0 +1,34 @@
+package depromeet.ohgzoo.iam.security.service;
+
+import depromeet.ohgzoo.iam.security.dto.AuthToken;
+import depromeet.ohgzoo.iam.security.exception.UnAuthenticationException;
+import depromeet.ohgzoo.iam.jwt.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Service
+@RequiredArgsConstructor
+public class TokenRefreshServiceImpl implements TokenRefreshService {
+
+    private static final String REFRESH_TOKEN = "REFRESH_TOKEN";
+    private final JwtService jwtService;
+
+    @Override
+    public AuthToken createNewAuthToken(HttpServletRequest request) throws UnAuthenticationException {
+        String refreshToken = request.getHeader(REFRESH_TOKEN);
+
+        if (StringUtils.hasText(refreshToken) && jwtService.verifyToken(refreshToken)) {
+            String email = jwtService.getSubject(refreshToken);
+
+            return new AuthToken(
+                    jwtService.issuedToken(email, "USER", 3600),
+                    jwtService.issuedToken(email, "USER", 36000)
+            );
+        } else {
+            throw new UnAuthenticationException("토큰이 만료되었습니다.");
+        }
+    }
+}

--- a/components/module-security/src/test/java/depromeet/ohgzoo/iam/ModuleSecurityApplication.java
+++ b/components/module-security/src/test/java/depromeet/ohgzoo/iam/ModuleSecurityApplication.java
@@ -1,0 +1,7 @@
+package depromeet.ohgzoo.iam;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ModuleSecurityApplication {
+}

--- a/components/module-security/src/test/java/depromeet/ohgzoo/iam/controller/TokenRefreshControllerTest.java
+++ b/components/module-security/src/test/java/depromeet/ohgzoo/iam/controller/TokenRefreshControllerTest.java
@@ -1,0 +1,99 @@
+package depromeet.ohgzoo.iam.controller;
+
+import depromeet.ohgzoo.iam.jwt.JwtServiceImpl;
+import depromeet.ohgzoo.iam.security.config.WebConfig;
+import depromeet.ohgzoo.iam.security.controller.TokenRefreshController;
+import depromeet.ohgzoo.iam.security.dto.AuthToken;
+import depromeet.ohgzoo.iam.security.exception.UnAuthenticationException;
+import depromeet.ohgzoo.iam.security.service.TokenRefreshService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TokenRefreshController.class)
+@Import(WebConfig.class)
+class TokenRefreshControllerTest {
+
+    @SpyBean
+    JwtServiceImpl jwtService;
+
+    @MockBean
+    TokenRefreshService tokenRefreshService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DisplayName("validToken")
+    public void validToken() throws Exception {
+        AuthToken authToken = new AuthToken(
+                jwtService.issuedToken("auth", "USER", 100000),
+                jwtService.issuedToken("refresh", "USER", 100000)
+        );
+
+        mockMvc.perform(get("/validtoken").header("AUTH_TOKEN", authToken.getAuth()))
+                .andExpect(status().isOk())
+                .andExpect(content().string("valid token"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("expiredToken")
+    public void expiredToken() throws Exception {
+        AuthToken authToken = new AuthToken(
+                jwtService.issuedToken("auth", "USER", 0),
+                jwtService.issuedToken("refresh", "USER", 100000)
+        );
+
+        mockMvc.perform(get("/validtoken").header("AUTH_TOKEN", authToken.getAuth()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/refresh?redirectURL=/validtoken"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("noToken")
+    public void noToken() throws Exception {
+        mockMvc.perform(get("/validtoken"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/refresh?redirectURL=/validtoken"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("refresh_성공")
+    public void refresh_성공() throws Exception {
+        AuthToken authToken = new AuthToken("auth", "refresh");
+        when(tokenRefreshService.createNewAuthToken(any())).thenReturn(authToken);
+
+        mockMvc.perform(get("/refresh"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.auth").value("auth"))
+                .andExpect(jsonPath("$.refresh").value("refresh"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("refresh_실패")
+    public void refresh_실패() throws Exception {
+        when(tokenRefreshService.createNewAuthToken(any())).thenThrow(new UnAuthenticationException("토큰이 만료되었습니다."));
+
+        mockMvc.perform(get("/refresh"))
+                .andExpect(jsonPath("$.msg").value("토큰이 만료되었습니다."))
+                .andExpect(jsonPath("$.code").value("401"))
+                .andExpect(status().isUnauthorized())
+                .andDo(print());
+    }
+
+}

--- a/components/module-security/src/test/java/depromeet/ohgzoo/iam/service/TokenRefreshServiceImplTest.java
+++ b/components/module-security/src/test/java/depromeet/ohgzoo/iam/service/TokenRefreshServiceImplTest.java
@@ -1,0 +1,57 @@
+package depromeet.ohgzoo.iam.service;
+
+import depromeet.ohgzoo.iam.security.dto.AuthToken;
+import depromeet.ohgzoo.iam.security.exception.UnAuthenticationException;
+import depromeet.ohgzoo.iam.jwt.JwtService;
+import depromeet.ohgzoo.iam.jwt.JwtServiceImpl;
+import depromeet.ohgzoo.iam.security.service.TokenRefreshServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TokenRefreshServiceImplTest {
+
+    JwtService jwtService = new JwtServiceImpl();
+    TokenRefreshServiceImpl tokenRefreshService = new TokenRefreshServiceImpl(jwtService);
+
+    @Test
+    @DisplayName("validRefreshToken")
+    public void validRefreshToken() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        AuthToken authToken = new AuthToken(
+                jwtService.issuedToken("email", "USER", 0),
+                jwtService.issuedToken("email", "USER", 1000000)
+        );
+        request.addHeader("REFRESH_TOKEN", authToken.getRefresh());
+        AuthToken newAuthToken = tokenRefreshService.createNewAuthToken(request);
+
+        assertThat(jwtService.getSubject(newAuthToken.getAuth())).isEqualTo("email");
+        assertThat(jwtService.getSubject(newAuthToken.getRefresh())).isEqualTo("email");
+    }
+
+    @Test
+    @DisplayName("expiredRefreshToken")
+    public void expiredRefreshToken() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        AuthToken authToken = new AuthToken(
+                jwtService.issuedToken("email", "USER", 0),
+                jwtService.issuedToken("email", "USER", 0)
+        );
+        request.addHeader("REFRESH_TOKEN", authToken.getRefresh());
+
+        assertThatThrownBy(() -> tokenRefreshService.createNewAuthToken(request))
+                .isInstanceOf(UnAuthenticationException.class);
+    }
+
+    @Test
+    @DisplayName("noRefreshToken")
+    public void noRefreshToken() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        assertThatThrownBy(() -> tokenRefreshService.createNewAuthToken(request))
+                .isInstanceOf(UnAuthenticationException.class);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,5 +2,7 @@ rootProject.name = 'iam'
 
 include ':applications:app-demo', ':components:module-demo'
 include ':components:module-oauth'
+include ':components:module-security'
+
 include ':components:support-feign'
 include ':components:support-jwt'


### PR DESCRIPTION
token inspection before dispatcher servlet is performed through Interceptor. If invalid, redirect to refresh; if the refresh token is valid, issue a new token; if invalid, throw a 401 error

### 🔖 ISSUE 종류를 선택하세요

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Release
- [ ] Misc (docs, test, style, ...)

### 🔖 내용
인터셉터를 통한 security 구현