### PR TITLE
fix : 폴더 글 없을시, 빈 배열로 표시

### DIFF
--- a/components/module-folder/src/main/java/depromeet/ohgzoo/iam/folder/FolderServiceImpl.java
+++ b/components/module-folder/src/main/java/depromeet/ohgzoo/iam/folder/FolderServiceImpl.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -71,10 +71,10 @@ public class FolderServiceImpl implements FolderService {
         List<Folder> folders = folderRepository.findAllByMemberId(memberId);
         List<FolderItem> folderItems = folderItemService.getRecentFolderItems(memberId);
 
-        List<String> coverImages = Arrays.asList(ImageLoader.DEFAULT_IMAGE, ImageLoader.DEFAULT_IMAGE, ImageLoader.DEFAULT_IMAGE, ImageLoader.DEFAULT_IMAGE);
+        List<String> coverImages = new ArrayList<>();
         for (int i = 0; i < folderItems.size(); i++) {
             if (folderItems.get(i) != null)
-                coverImages.set(i, folderItems.get(i).getFirstCategory().getImage());
+                coverImages.add(folderItems.get(i).getFirstCategory().getImage());
         }
 
         return new FoldersGetResponse(folders.stream()

--- a/components/module-folder/src/test/java/depromeet/ohgzoo/iam/folder/FolderServiceImplTest.java
+++ b/components/module-folder/src/test/java/depromeet/ohgzoo/iam/folder/FolderServiceImplTest.java
@@ -1,7 +1,6 @@
 package depromeet.ohgzoo.iam.folder;
 
 import depromeet.ohgzoo.iam.category.FirstCategory;
-import depromeet.ohgzoo.iam.category.ImageLoader;
 import depromeet.ohgzoo.iam.category.SecondCategory;
 import depromeet.ohgzoo.iam.folder.folderItem.FolderItem;
 import depromeet.ohgzoo.iam.folder.folderItem.FolderItemCreateRequest;
@@ -361,8 +360,6 @@ public class FolderServiceImplTest {
         assertThat(result.getFolders().get(0).getFolderId()).isEqualTo(1L);
         assertThat(result.getFolders().get(0).getFolderName()).isEqualTo("folder name");
         assertThat(result.getFolders().get(1).getFolderId()).isEqualTo(2L);
-
-        assertThat(result.getPostsThumbnail().get(0)).isEqualTo(ImageLoader.DEFAULT_IMAGE);
     }
 
     @Test


### PR DESCRIPTION
### 🔖 ISSUE 종류를 선택하세요

- [ ] Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Release
- [ ] Misc (docs, test, style, ...)

### 🔖 내용
- 프론트 요청으로 폴더글 없을시, 디폴트 이미지가 아닌 빈 배열 전달로 수정했습니다.